### PR TITLE
Expose SerializerChain

### DIFF
--- a/src/main/java/spark/Spark.java
+++ b/src/main/java/spark/Spark.java
@@ -16,7 +16,11 @@
  */
 package spark;
 
+import spark.embeddedserver.jetty.EmbeddedJettyServer;
+import spark.embeddedserver.jetty.JettyHandler;
+import spark.http.matching.MatcherFilter;
 import spark.routematch.RouteMatch;
+import spark.serialization.SerializerChain;
 
 import java.util.List;
 import java.util.function.Consumer;
@@ -1328,5 +1332,10 @@ public class Spark {
         return getInstance().activeThreadCount();
     }
 
-
+    public static SerializerChain getSerializerChain(){
+        EmbeddedJettyServer ejs=(EmbeddedJettyServer) getInstance().server;
+        JettyHandler handler=(JettyHandler) ejs.getHandler();
+        MatcherFilter filter=(MatcherFilter) handler.getFilter();
+        return filter.getSerializerChain();
+    }
 }

--- a/src/main/java/spark/embeddedserver/jetty/EmbeddedJettyServer.java
+++ b/src/main/java/spark/embeddedserver/jetty/EmbeddedJettyServer.java
@@ -198,4 +198,8 @@ public class EmbeddedJettyServer implements EmbeddedServer {
         this.threadPool = threadPool;
         return this;
     }
+
+    public Handler getHandler(){
+        return handler;
+    }
 }

--- a/src/main/java/spark/embeddedserver/jetty/JettyHandler.java
+++ b/src/main/java/spark/embeddedserver/jetty/JettyHandler.java
@@ -57,4 +57,7 @@ public class JettyHandler extends SessionHandler {
 
     }
 
+    public Filter getFilter(){
+        return filter;
+    }
 }

--- a/src/main/java/spark/http/matching/Body.java
+++ b/src/main/java/spark/http/matching/Body.java
@@ -22,6 +22,8 @@ import java.io.OutputStream;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import spark.Request;
+import spark.Response;
 import spark.utils.GzipUtils;
 import spark.serialization.SerializerChain;
 
@@ -58,7 +60,7 @@ final class Body {
 
     public void serializeTo(HttpServletResponse httpResponse,
                             SerializerChain serializerChain,
-                            HttpServletRequest httpRequest) throws IOException {
+                            HttpServletRequest httpRequest, Request requestWrapper, Response responseWrapper) throws IOException {
 
         if (!httpResponse.isCommitted()) {
             if (httpResponse.getContentType() == null) {
@@ -69,7 +71,7 @@ final class Body {
             OutputStream responseStream = GzipUtils.checkAndWrap(httpRequest, httpResponse, true);
 
             // Serialize the body to output stream
-            serializerChain.process(responseStream, content);
+            serializerChain.process(responseStream, content, requestWrapper, responseWrapper);
 
             responseStream.flush(); // needed for GZIP stream. Not sure where the HTTP response actually gets cleaned up
             responseStream.close(); // needed for GZIP

--- a/src/main/java/spark/http/matching/MatcherFilter.java
+++ b/src/main/java/spark/http/matching/MatcherFilter.java
@@ -190,7 +190,7 @@ public class MatcherFilter implements Filter {
         }
 
         if (body.isSet()) {
-            body.serializeTo(httpResponse, serializerChain, httpRequest);
+            body.serializeTo(httpResponse, serializerChain, httpRequest, requestWrapper, responseWrapper);
         } else if (chain != null) {
             chain.doFilter(httpRequest, httpResponse);
         }

--- a/src/main/java/spark/http/matching/MatcherFilter.java
+++ b/src/main/java/spark/http/matching/MatcherFilter.java
@@ -209,5 +209,7 @@ public class MatcherFilter implements Filter {
     public void destroy() {
     }
 
-
+    public SerializerChain getSerializerChain(){
+        return serializerChain;
+    }
 }

--- a/src/main/java/spark/serialization/BytesSerializer.java
+++ b/src/main/java/spark/serialization/BytesSerializer.java
@@ -20,6 +20,9 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 
+import spark.Request;
+import spark.Response;
+
 /**
  * Bytes serializer.
  *
@@ -33,7 +36,7 @@ class BytesSerializer extends Serializer {
     }
 
     @Override
-    public void process(OutputStream outputStream, Object element)
+    public void process(OutputStream outputStream, Object element, Request request, Response response)
             throws IOException {
         byte[] bytes = null;
         if (element instanceof byte[]) {

--- a/src/main/java/spark/serialization/DefaultSerializer.java
+++ b/src/main/java/spark/serialization/DefaultSerializer.java
@@ -20,6 +20,9 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 
+import spark.Request;
+import spark.Response;
+
 /**
  * Serializer that writes the result of toString to output in UTF-8 encoding
  *
@@ -33,7 +36,7 @@ class DefaultSerializer extends Serializer {
     }
 
     @Override
-    public void process(OutputStream outputStream, Object element) throws IOException {
+    public void process(OutputStream outputStream, Object element, Request request, Response response) throws IOException {
         try {
             outputStream.write(element.toString().getBytes("utf-8"));
         } catch (UnsupportedEncodingException e) {

--- a/src/main/java/spark/serialization/InputStreamSerializer.java
+++ b/src/main/java/spark/serialization/InputStreamSerializer.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+import spark.Request;
+import spark.Response;
 import spark.utils.IOUtils;
 
 /**
@@ -35,7 +37,7 @@ class InputStreamSerializer extends Serializer {
     }
 
     @Override
-    public void process(OutputStream outputStream, Object element)
+    public void process(OutputStream outputStream, Object element, Request request, Response response)
             throws IOException {
         try (InputStream is = (InputStream) element) {
             IOUtils.copy(is, outputStream);

--- a/src/main/java/spark/serialization/Serializer.java
+++ b/src/main/java/spark/serialization/Serializer.java
@@ -19,6 +19,9 @@ package spark.serialization;
 import java.io.IOException;
 import java.io.OutputStream;
 
+import spark.Request;
+import spark.Response;
+
 /**
  * Class that serializers and writes the result to given output stream.
  *
@@ -38,18 +41,20 @@ public abstract class Serializer {
     }
 
     /**
-     * Wraps {@link Serializer#process(java.io.OutputStream, Object)} and calls next serializer in chain.
+     * Wraps {@link Serializer#process(OutputStream, Object, Request, Response)} and calls next serializer in chain.
      *
      * @param outputStream the output stream.
      * @param element      the element to process.
+     * @param request
+     * @param response
      * @throws IOException IOException in case of IO error.
      */
-    public void processElement(OutputStream outputStream, Object element) throws IOException {
+    public void processElement(OutputStream outputStream, Object element, Request request, Response response) throws IOException {
         if (canProcess(element)) {
-            process(outputStream, element);
+            process(outputStream, element, request, response);
         } else {
             if (next != null) {
-                this.next.processElement(outputStream, element);
+                this.next.processElement(outputStream, element, request, response);
             }
         }
     }
@@ -67,7 +72,9 @@ public abstract class Serializer {
      *
      * @param outputStream the output stream.
      * @param element      the element.
+     * @param request
+     * @param response
      * @throws IOException In the case of IO error.
      */
-    public abstract void process(OutputStream outputStream, Object element) throws IOException;
+    public abstract void process(OutputStream outputStream, Object element, Request request, Response response) throws IOException;
 }

--- a/src/main/java/spark/serialization/SerializerChain.java
+++ b/src/main/java/spark/serialization/SerializerChain.java
@@ -19,6 +19,9 @@ package spark.serialization;
 import java.io.IOException;
 import java.io.OutputStream;
 
+import spark.Request;
+import spark.Response;
+
 /**
  * Chain of serializers for the output.
  */
@@ -47,10 +50,12 @@ public final class SerializerChain {
      *
      * @param outputStream the output stream to write to.
      * @param element      the element to serialize.
+     * @param request
+     * @param response
      * @throws IOException in the case of IO error.
      */
-    public void process(OutputStream outputStream, Object element) throws IOException {
-        this.root.processElement(outputStream, element);
+    public void process(OutputStream outputStream, Object element, Request request, Response response) throws IOException {
+        this.root.processElement(outputStream, element, request, response);
     }
 
 }

--- a/src/main/java/spark/serialization/SerializerChain.java
+++ b/src/main/java/spark/serialization/SerializerChain.java
@@ -58,4 +58,8 @@ public final class SerializerChain {
         this.root.processElement(outputStream, element, request, response);
     }
 
+    public void insertBeforeRoot(Serializer serializer){
+        serializer.setNext(root);
+        root=serializer;
+    }
 }

--- a/src/test/java/spark/serialization/InputStreamSerializerTest.java
+++ b/src/test/java/spark/serialization/InputStreamSerializerTest.java
@@ -15,7 +15,7 @@ public class InputStreamSerializerTest {
         ByteArrayInputStream input = new ByteArrayInputStream(bytes);
         ByteArrayOutputStream output = new ByteArrayOutputStream();
 
-        serializer.process(output, input);
+        serializer.process(output, input, null, null);
 
         Assert.assertArrayEquals(bytes, output.toByteArray());
     }
@@ -25,7 +25,7 @@ public class InputStreamSerializerTest {
         MockInputStream input = new MockInputStream(new ByteArrayInputStream(new byte[0]));
         ByteArrayOutputStream output = new ByteArrayOutputStream();
 
-        serializer.process(output, input);
+        serializer.process(output, input, null, null);
 
         Assert.assertTrue("Expected stream to be closed", input.closed);
     }


### PR DESCRIPTION
This allows setting custom serializers so responses could be streamed, instead of rendering the response into a string or a byte array and only then starting to write it out to the client. Gives a significant performance boost when used, for example, with a template engine that supports outputting to a Writer or OutputStream.