### PR TITLE
Fix Spark error pages when there are websocket routes

### DIFF
--- a/src/main/java/spark/embeddedserver/jetty/EmbeddedJettyServer.java
+++ b/src/main/java/spark/embeddedserver/jetty/EmbeddedJettyServer.java
@@ -28,6 +28,7 @@ import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.HandlerList;
+import org.eclipse.jetty.servlet.ErrorPageErrorHandler;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.util.thread.ThreadPool;
 import org.slf4j.Logger;
@@ -36,6 +37,7 @@ import org.slf4j.LoggerFactory;
 import spark.embeddedserver.EmbeddedServer;
 import spark.embeddedserver.jetty.websocket.WebSocketHandlerWrapper;
 import spark.embeddedserver.jetty.websocket.WebSocketServletContextHandlerFactory;
+import spark.http.matching.MatcherFilter;
 import spark.ssl.SslStores;
 
 /**
@@ -135,8 +137,10 @@ public class EmbeddedJettyServer implements EmbeddedServer {
             handlersInList.add(handler);
 
             // WebSocket handler must be the last one
-            if (webSocketServletContextHandler != null) {
-                handlersInList.add(webSocketServletContextHandler);
+            handlersInList.add(webSocketServletContextHandler);
+
+            if (handler instanceof JettyHandler jh && jh.getFilter() instanceof MatcherFilter matcherFilter) {
+                webSocketServletContextHandler.setErrorHandler(new JettyErrorHandler(matcherFilter));
             }
 
             HandlerList handlers = new HandlerList();

--- a/src/main/java/spark/embeddedserver/jetty/JettyErrorHandler.java
+++ b/src/main/java/spark/embeddedserver/jetty/JettyErrorHandler.java
@@ -1,0 +1,39 @@
+package spark.embeddedserver.jetty;
+
+import org.eclipse.jetty.server.handler.ErrorHandler;
+
+import java.io.IOException;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import spark.CustomErrorPages;
+import spark.Request;
+import spark.RequestResponseFactory;
+import spark.Response;
+import spark.http.matching.Body;
+import spark.http.matching.MatcherFilter;
+import spark.serialization.SerializerChain;
+
+public class JettyErrorHandler extends ErrorHandler {
+    private final MatcherFilter matcherFilter;
+
+    public JettyErrorHandler(MatcherFilter matcherFilter) {
+        this.matcherFilter=matcherFilter;
+    }
+
+    @Override
+    protected void generateAcceptableResponse(org.eclipse.jetty.server.Request baseRequest, HttpServletRequest servletRequest,
+                                              HttpServletResponse servletResponse, int code, String message, String contentType) throws IOException {
+        if (CustomErrorPages.existsFor(code)) {
+            Request request = RequestResponseFactory.create(servletRequest);
+            Response response = RequestResponseFactory.create(servletResponse);
+            SerializerChain serializer = matcherFilter.getSerializerChain();
+            Object page = CustomErrorPages.getFor(code, request, response);
+            Body body = Body.create();
+            body.set(page);
+            body.serializeTo(servletResponse, serializer, servletRequest, request, response);
+        } else {
+            super.generateAcceptableResponse(baseRequest, servletRequest, servletResponse, code, message, contentType);
+        }
+    }
+}

--- a/src/main/java/spark/http/matching/Body.java
+++ b/src/main/java/spark/http/matching/Body.java
@@ -30,7 +30,7 @@ import spark.serialization.SerializerChain;
 /**
  * Represents the 'body'
  */
-final class Body {
+public final class Body {
 
     private Object content;
 


### PR DESCRIPTION
Without this, you would always get Jetty error pages because the Spark handler would not catch errors because of how it's configured.