### PR TITLE
Jetty 11.0.15 -> 11.0.24, slf4j 2.0.16 -> 2.0.17,

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: Spark Framework CI
 
 on:
   push:
-  pull_request:
 
 jobs:
   build:

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,8 @@
     <properties>
         <gpg.skip>false</gpg.skip>
         <java.version>17</java.version>
-        <jetty.version>11.0.15</jetty.version>
+        <jetty.version>11.0.24</jetty.version>
+        <slf4j.version>2.0.17</slf4j.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <mockito.version>5.15.2</mockito.version>
     </properties>
@@ -43,13 +44,13 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.16</version>
+            <version>${slf4j.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>2.0.16</version>
+            <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -81,7 +82,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -93,19 +94,19 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.6</version>
+            <version>4.5.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
-            <version>2.3.28</version>
+            <version>2.3.34</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.5</version>
+            <version>2.12.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
junit 4.12 -> 4.13.2,
httpclient 4.5.6 -> 4.5.14,
freemarker 2.3.28 -> 2.3.34,
gson 2.8.5 -> 2.12.1