### PR TITLE
Fix bugs within Exception Mapping when running with a ServletFilter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: Spark Framework CI
 
 on:
   push:
+  pull_request:
 
 jobs:
   build:
@@ -9,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ '17', '21' ]
+        java: [ '17', '21', '25' ]
     name: Java Version ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v4

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,1 @@
--Drevision=2.9.4
+-Drevision=2.9.5

--- a/docs-source/release-notes.md
+++ b/docs-source/release-notes.md
@@ -18,6 +18,12 @@ Updating to Jetty 12 would be a too big change for this release.
 - #12: Update some versions: Jetty 11.0.24, slf4j 2.0.17, ...
 - #14: Set response body in after after
 
+## 2.9.5
+
+- #20: Fixes [perwendel/spark#1062](https://github.com/perwendel/spark/issues/1062) by ensuring exception mappers are registered/called correctly when running within a servlet.
+- #20: Fixes [perwendel/spark#1010](https://github.com/perwendel/spark/issues/1010) by improving thread safety of exception mappers.
+- #20: Fixes [perwendel/spark#1213](https://github.com/perwendel/spark/issues/1213) by ensuring exception mappers are cleared when ServletFilters are destroyed.
+
 ## 2.9.4
 
 The release 2.9.4 is identical to the last release 2.9.4 by Per Wendel.

--- a/docs-source/vars
+++ b/docs-source/vars
@@ -1,1 +1,1 @@
-version=2.9.4
+version=2.9.5

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <jetty.version>11.0.24</jetty.version>
         <slf4j.version>2.0.17</slf4j.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <mockito.version>5.15.2</mockito.version>
+        <mockito.version>5.21.0</mockito.version>
     </properties>
 
     <dependencies>
@@ -140,7 +140,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
+                <version>3.14.1</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
@@ -149,13 +149,25 @@
                 </configuration>
             </plugin>
             <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.9.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M4</version>
+                <version>3.5.4</version>
                 <configuration>
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
                     <argLine>
+                        -javaagent:${org.mockito:mockito-core:jar}
                         --add-opens java.base/java.lang=ALL-UNNAMED
                         --add-opens java.base/java.time=ALL-UNNAMED
                         --add-opens java.base/java.time.format=ALL-UNNAMED
@@ -167,22 +179,30 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.12.0</version>
                 <configuration>
                     <failOnError>false</failOnError>
                     <doclint>none</doclint>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>6.0.0</version>
                 <extensions>true</extensions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.6</version>
+                <version>3.2.8</version>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
@@ -196,7 +216,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.4.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -207,22 +227,9 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.5.0</version>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>0.7.0</version>
+                <version>0.9.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <publishingServerId>central</publishingServerId>

--- a/src/main/java/spark/ExceptionMapper.java
+++ b/src/main/java/spark/ExceptionMapper.java
@@ -16,8 +16,8 @@
  */
 package spark;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class ExceptionMapper {
 
@@ -32,13 +32,18 @@ public class ExceptionMapper {
     }
 
     /**
-     * Returns exception mapper instance used in servlet mode
+     * Returns shared exception mapper instance used in servlet mode
      *
      * @return servlet instance
      */
-    public synchronized static ExceptionMapper getServletInstance() {
-        if (servletInstance == null) {
-            servletInstance = new ExceptionMapper();
+    public static ExceptionMapper getServletInstance() {
+        if (servletInstance != null) {
+            return servletInstance;
+        }
+        synchronized (ExceptionMapper.class) {
+            if (servletInstance == null) {
+                servletInstance = new ExceptionMapper();
+            }
         }
         return servletInstance;
     }
@@ -46,13 +51,13 @@ public class ExceptionMapper {
     /**
      * Holds a map of Exception classes and associated handlers
      */
-    private Map<Class<? extends Exception>, ExceptionHandlerImpl<?>> exceptionMap;
+    private final Map<Class<? extends Exception>, ExceptionHandlerImpl<?>> exceptionMap;
 
     /**
      * Class constructor
      */
     public ExceptionMapper() {
-        this.exceptionMap = new HashMap<>();
+        this.exceptionMap = new ConcurrentHashMap<>();
     }
 
     /**

--- a/src/main/java/spark/ExceptionMapper.java
+++ b/src/main/java/spark/ExceptionMapper.java
@@ -21,6 +21,13 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class ExceptionMapper {
 
+    private static final ExceptionHandlerImpl<Exception> cachedNoOpHandler = new ExceptionHandlerImpl<>(null) {
+        @Override
+        public void handle(Exception exception, Request request, Response response) {
+
+        }
+    };
+
     /**
      * Holds an exception mapper instance for use in servlet mode
      */
@@ -80,31 +87,37 @@ public class ExceptionMapper {
     public ExceptionHandlerImpl<?> getHandler(Class<? extends Exception> exceptionClass) {
         // If the exception map does not contain the provided exception class, it might
         // still be that a superclass of the exception class is.
-        if (!this.exceptionMap.containsKey(exceptionClass)) {
+        ExceptionHandlerImpl<?> handler = this.exceptionMap.get(exceptionClass);
 
+        if (handler == null) {
             Class<?> superclass = exceptionClass.getSuperclass();
-            do {
+            while (superclass != null) {
                 // Is the superclass mapped?
-                if (this.exceptionMap.containsKey(superclass)) {
+                handler = this.exceptionMap.get(superclass);
+
+                if (handler != null) {
                     // Use the handler for the mapped superclass, and cache handler
                     // for this exception class
-                    ExceptionHandlerImpl<?> handler = this.exceptionMap.get(superclass);
-                    this.exceptionMap.put(exceptionClass, handler);
-                    return handler;
+                    this.exceptionMap.putIfAbsent(exceptionClass, handler);
+                    return unwrapifNecessary(handler);
                 }
 
                 // Iteratively walk through the exception class's superclasses
                 superclass = superclass.getSuperclass();
-            } while (superclass != null);
+            }
 
             // No handler found either for the superclasses of the exception class
-            // We cache the null value to prevent future
-            this.exceptionMap.put(exceptionClass, null);
+            // We cache the null value to prevent future lookups
+            this.exceptionMap.putIfAbsent(exceptionClass, cachedNoOpHandler);
             return null;
         }
 
         // Direct map
-        return this.exceptionMap.get(exceptionClass);
+        return unwrapifNecessary(handler);
+    }
+
+    private static ExceptionHandlerImpl<?> unwrapifNecessary(ExceptionHandlerImpl<?> handler) {
+        return cachedNoOpHandler == handler ? null : handler;
     }
 
     /**
@@ -124,4 +137,7 @@ public class ExceptionMapper {
         this.exceptionMap.clear();
     }
 
+    int size() {
+        return this.exceptionMap.size();
+    }
 }

--- a/src/main/java/spark/Service.java
+++ b/src/main/java/spark/Service.java
@@ -95,7 +95,7 @@ public final class Service extends Routable {
     public final StaticFiles staticFiles;
 
     private final StaticFilesConfiguration staticFilesConfiguration;
-    private final ExceptionMapper exceptionMapper = new ExceptionMapper();
+    private final ExceptionMapper exceptionMapper;
 
     // default exception handler during initialization phase
     private Consumer<Exception> initExceptionHandler = (e) -> {
@@ -121,8 +121,10 @@ public final class Service extends Routable {
 
         if (isRunningFromServlet()) {
             staticFilesConfiguration = StaticFilesConfiguration.servletInstance;
+            exceptionMapper = ExceptionMapper.getServletInstance();
         } else {
             staticFilesConfiguration = StaticFilesConfiguration.create();
+            exceptionMapper = new ExceptionMapper();
         }
     }
 

--- a/src/main/java/spark/globalstate/ServletFlag.java
+++ b/src/main/java/spark/globalstate/ServletFlag.java
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public class ServletFlag {
 
-    private static AtomicBoolean isRunningFromServlet = new AtomicBoolean(false);
+    private static final AtomicBoolean isRunningFromServlet = new AtomicBoolean(false);
 
     /**
      * Tells the system that Spark was run from an "external" web application server.

--- a/src/main/java/spark/servlet/SparkFilter.java
+++ b/src/main/java/spark/servlet/SparkFilter.java
@@ -181,6 +181,7 @@ public class SparkFilter implements Filter {
                 sparkApplication.destroy();
             }
         }
+        ExceptionMapper.getServletInstance().clear();
     }
 
 }

--- a/src/test/java/spark/ExceptionMapperTest.java
+++ b/src/test/java/spark/ExceptionMapperTest.java
@@ -1,6 +1,6 @@
 package spark;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 import java.lang.reflect.Field;
 
@@ -15,7 +15,7 @@ public class ExceptionMapperTest {
 		instanceField.set(null, null);
 		
 		ExceptionMapper exceptionMapper = ExceptionMapper.getServletInstance();
-		assertEquals("Should be equal because ExceptionMapper is a singleton", instanceField.get(null), exceptionMapper);
+		assertSame("Should be same because ExceptionMapper is a singleton", instanceField.get(null), exceptionMapper);
 	}
 
 	@Test
@@ -26,6 +26,6 @@ public class ExceptionMapperTest {
 		ExceptionMapper.getServletInstance(); // initialize singleton
 		
 		ExceptionMapper exceptionMapper = ExceptionMapper.getServletInstance();
-		assertEquals("Should be equal because ExceptionMapper is a singleton", instanceField.get(null), exceptionMapper);
+		assertSame("Should be same because ExceptionMapper is a singleton", instanceField.get(null), exceptionMapper);
 	}
 }

--- a/src/test/java/spark/ExceptionMapperTest.java
+++ b/src/test/java/spark/ExceptionMapperTest.java
@@ -1,14 +1,27 @@
 package spark;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
+import java.io.IOException;
 import java.lang.reflect.Field;
 
 import org.junit.Test;
 
 public class ExceptionMapperTest {
 
-	@Test
+    private final ExceptionHandlerImpl<Exception> testHandler = newHandler();
+
+    private static ExceptionHandlerImpl<Exception> newHandler() {
+        return new ExceptionHandlerImpl<>(Exception.class) {
+            @Override
+            public void handle(Exception exception, Request request, Response response) {
+            }
+        };
+    }
+
+    @Test
 	public void testGetInstance_whenDefaultInstanceIsNull() throws Exception {
 		Field instanceField = ExceptionMapper.class.getDeclaredField("servletInstance");
 		instanceField.setAccessible(true);
@@ -28,4 +41,54 @@ public class ExceptionMapperTest {
 		ExceptionMapper exceptionMapper = ExceptionMapper.getServletInstance();
 		assertSame("Should be same because ExceptionMapper is a singleton", instanceField.get(null), exceptionMapper);
 	}
+
+    @Test
+    public void testGetNullIfNoHandler() {
+        ExceptionMapper mapper = new ExceptionMapper();
+        assertNull(mapper.getHandler(new Exception()));
+        assertEquals("expect result to be cached", 1, mapper.size());
+    }
+
+    @Test
+    public void testGetDirectlyMappedExceptionHandler() {
+        ExceptionMapper mapper = new ExceptionMapper();
+        mapper.map(Exception.class, testHandler);
+
+        assertSame(testHandler, mapper.getHandler(new Exception()));
+        assertEquals(1, mapper.size());
+    }
+
+    @Test
+    public void testGetSuperclassMappedExceptionHandler() {
+        ExceptionMapper mapper = new ExceptionMapper();
+        mapper.map(Exception.class, testHandler);
+        assertEquals(1, mapper.size());
+
+        assertSame(testHandler, mapper.getHandler(new RuntimeException()));
+        assertEquals("expect result to be cached", 2, mapper.size());
+    }
+
+    @Test
+    public void testGetSuperclassMappedExceptionHandlerWithThreeLevels() {
+        ExceptionMapper mapper = new ExceptionMapper();
+        mapper.map(Exception.class, testHandler);
+        assertEquals(1, mapper.size());
+
+        assertSame(testHandler, mapper.getHandler(new CustomRuntimeException()));
+        assertEquals("expect result to be cached only at requested level", 2, mapper.size());
+    }
+
+    @Test
+    public void testGetSuperclassMappedExceptionHandlerFindsFirstAppropriateHandler() {
+        ExceptionMapper mapper = new ExceptionMapper();
+        ExceptionHandlerImpl<Exception> anotherHandler = newHandler();
+        mapper.map(Exception.class, anotherHandler);
+        mapper.map(RuntimeException.class, testHandler);
+
+        assertSame(testHandler, mapper.getHandler(new CustomRuntimeException()));
+        assertSame(anotherHandler, mapper.getHandler(new Exception()));
+        assertSame(anotherHandler, mapper.getHandler(new IOException()));
+    }
+
+    private static class CustomRuntimeException extends RuntimeException {}
 }

--- a/src/test/java/spark/ServiceTest.java
+++ b/src/test/java/spark/ServiceTest.java
@@ -1,9 +1,9 @@
 package spark;
 
 import jakarta.servlet.http.HttpServletResponse;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 import static spark.Service.ignite;
 
 import org.eclipse.jetty.websocket.api.annotations.WebSocket;
@@ -11,10 +11,12 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import spark.embeddedserver.EmbeddedServer;
 import spark.embeddedserver.EmbeddedServers;
+import spark.globalstate.ServletFlag;
 import spark.route.Routes;
 import spark.ssl.SslStores;
 
@@ -267,12 +269,12 @@ public class ServiceTest {
         thrown.expectMessage("WebSocket handler class cannot be null");
         service.webSocket("/", null);
     }
-    
+
     @Test(timeout = 300)
     public void stopExtinguishesServer() {
         Service service = Service.ignite();
-        Routes routes = Mockito.mock(Routes.class);
-        EmbeddedServer server = Mockito.mock(EmbeddedServer.class);
+        Routes routes = mock(Routes.class);
+        EmbeddedServer server = mock(EmbeddedServer.class);
         service.routes = routes;
         service.server = server;
         service.initialized = true;
@@ -291,8 +293,8 @@ public class ServiceTest {
     @Test
     public void awaitStopBlocksUntilExtinguished() {
         Service service = Service.ignite();
-        Routes routes = Mockito.mock(Routes.class);
-        EmbeddedServer server = Mockito.mock(EmbeddedServer.class);
+        Routes routes = mock(Routes.class);
+        EmbeddedServer server = mock(EmbeddedServer.class);
         service.routes = routes;
         service.server = server;
         service.initialized = true;
@@ -305,4 +307,54 @@ public class ServiceTest {
     @WebSocket
     protected static class DummyWebSocketListener {
     }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void exceptionMapperUsesDedicatedMapperWhenRunningEmbedded() {
+        ExceptionHandler<Exception> handler = mock(ExceptionHandler.class);
+
+        Service service;
+        try (MockedStatic<ServletFlag> servletFlag = Mockito.mockStatic(ServletFlag.class)) {
+            servletFlag.when(ServletFlag::isRunningFromServlet).thenReturn(false);
+
+            service = Service.ignite();
+            service.exception(Exception.class, handler);
+        }
+
+        try {
+            RuntimeException testException = new RuntimeException();
+            assertNull(ExceptionMapper.getServletInstance().getHandler(testException));
+        } finally {
+            ExceptionMapper.getServletInstance().clear();
+            service.stop();
+            service.awaitStop();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void exceptionMapperUsesServletInstanceWhenRunningFromServlet() {
+        ExceptionHandler<Exception> handler = mock(ExceptionHandler.class);
+
+        Service service;
+        try (MockedStatic<ServletFlag> servletFlag = Mockito.mockStatic(ServletFlag.class)) {
+            servletFlag.when(ServletFlag::isRunningFromServlet).thenReturn(true);
+
+            service = Service.ignite();
+            service.exception(Exception.class, handler);
+        }
+
+        try {
+            RuntimeException testException = new RuntimeException();
+            ExceptionHandlerImpl<Exception> servletHandler = (ExceptionHandlerImpl<Exception>) ExceptionMapper.getServletInstance().getHandler(testException);
+            servletHandler.handle(testException, null, null);
+
+            verify(handler).handle(testException, null, null);
+        } finally {
+            ExceptionMapper.getServletInstance().clear();
+            service.stop();
+            service.awaitStop();
+        }
+    }
+
 }


### PR DESCRIPTION
As raised at https://github.com/sparkjavateam/spark/discussions/19 this proposed patch addresses 3 adjacent issues with ExceptionMappers that were introduced in Spark 2.8.0 and have been latent for a long time.:
- https://github.com/perwendel/spark/issues/1062
- https://github.com/perwendel/spark/issues/1010
- https://github.com/perwendel/spark/issues/1213

As the changes to release notes/versions suggest, if possible I would actually prefer for this to be a 2.9.5 release, so if the maintainers are open to this, I'd prefer if someone could create a `2.9.x` branch and I'l retarget the branch there, or backport it.

My project isn't read to move to the jakarta namespace yet; but getting Spark to a current version is part of making that easier.

```
[INFO] Results:
[WARNING] Tests run: 315, Failures: 0, Errors: 0, Skipped: 2
```